### PR TITLE
Disable trackActivity on new accounts by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,4 @@ yarn db:update
 
 ## License
 This project is under the [GNU Affero General Public License v3.0](https://github.com/nove-org/NAPI/blob/main/LICENSE)
+ 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,7 +21,7 @@ model User {
   emailVerifyCode  String
   token            String
   profilePublic    Boolean  @default(false)
-  trackActivity    Boolean  @default(true)
+  trackActivity    Boolean  @default(false)
   mfaEnabled       Boolean  @default(false)
   mfaSecret        String   @default("")
   mfaRecoveryCodes String[]


### PR DESCRIPTION
## Changes

-   disabled trackActivity on new accounts by default

*Resolves NOVE-R-001 on security audit with ID "pi8L87KjGU6s" performed on 23 August 2023 by Oliwier Jaszczyszyn.*